### PR TITLE
Remove unsupported user satisfaction claims

### DIFF
--- a/PRD.md
+++ b/PRD.md
@@ -114,7 +114,7 @@ Making personalized mindfulness accessible through technology.
 - **Usage Pattern Tracking**: Monitors completion rates, preferred times, session effectiveness
 - **Relief Outcome Tracking**: Post-session feedback improves future recommendations
 - **A/B Testing Framework**: Continuous optimization of recommendation algorithms
-- **Performance Metrics**: Tracks time-to-play, tap counts, user satisfaction
+- **Performance Metrics**: Tracks time-to-play and tap counts
 
 #### 5. Seamless User Experience
 - **Fast Load Times**: App ready in <5 seconds, audio starts in <2 seconds
@@ -471,7 +471,7 @@ Making personalized mindfulness accessible through technology.
 #### Product Education Content
 - **AI Technology Explanation**: How intent prediction works (simplified for general audience)
 - **Use Case Scenarios**: Specific workplace stress situations and ZenShift solutions
-- **Effectiveness Evidence**: User outcome data, completion rates, satisfaction metrics
+- **Effectiveness Evidence**: User outcome data and completion rates
 - **Professional Relevance**: Integration with work schedules, quick session benefits, productivity impact
 
 #### Trust and Transparency Content
@@ -664,7 +664,7 @@ Making personalized mindfulness accessible through technology.
 - **Mitigation Strategies**:
   - Emphasize AI technology sophistication and innovation
   - Include specific workplace use cases and professional testimonials
-  - Highlight performance metrics (speed, effectiveness, user satisfaction)
+  - Highlight performance metrics (speed and effectiveness)
   - Position against consumer apps with clear professional differentiation
   - Add case studies or examples from actual professional users
 

--- a/accessibility.html
+++ b/accessibility.html
@@ -104,7 +104,7 @@
       <li>CSS3</li>
       <li>JavaScript (ES6+)</li>
       <li>ARIA (Accessible Rich Internet Applications) attributes</li>
-    </li>
+    </ul>
 
     <h2>Compliance Status</h2>
     <p>This website aims to conform to WCAG 2.1 Level AA. We recognize that accessibility is an ongoing effort and continue to identify and address areas for improvement.</p>

--- a/index.html
+++ b/index.html
@@ -426,10 +426,6 @@
           <div class="company-visual">
             <div class="company-stats">
               <div class="stat-card">
-                <div class="stat-number">90%</div>
-                <div class="stat-label">User Satisfaction</div>
-              </div>
-              <div class="stat-card">
                 <div class="stat-number">3 sec</div>
                 <div class="stat-label">Average Time to Relief</div>
               </div>


### PR DESCRIPTION
## Summary
- remove the user satisfaction stat card from the company section to avoid unsupported claims
- update PRD performance and evidence bullets to drop references to user satisfaction metrics
- fix the accessibility statement list markup so it closes correctly

## Testing
- python3 - <<'PY' ...

------
https://chatgpt.com/codex/tasks/task_e_68d0a50f15c8832c9440177d09960494